### PR TITLE
Update home.jinja2

### DIFF
--- a/microsetta_interface/templates/home.jinja2
+++ b/microsetta_interface/templates/home.jinja2
@@ -25,22 +25,22 @@
     </div>
     {% else %}
     <p>
-        It appears that your email has not yet been verified.
-        Please check your email account (and spam folder) for a verification email
-        from "The Microsetta Initiative" and follow its instructions.
-        This email will come from our authentication service AuthRocket,
-        and use the email address "noreply@loginrocket.com".
+        To continue: Check your email account to obtain your confirmation email and link, which was sent to confirm your account.
+        This email will come from our authentication service, AuthRocket, under the email address "noreply@loginrocket.com".
     </p>
     <p>
-        If you cannot locate the original verification email, have it resent by
-        clicking <a href = "{{ authrocket_url }}/profile">here</a> to view your AuthRocket profile and then
-        clicking the "resend verification email" link.
+        If you cannot locate the original confirmation email, have it resent by
+        clicking the button below to view your AuthRocket profile, and then
+        clicking the "resend verification email" link next to your email address.
     </p>
     <p>
-        <button class = "btn btn-primary" onclick="window.location.replace('{{authrocket_url}}/login?redirect_uri={{endpoint}}/authrocket_callback');">
-            Refresh
-        </button>
+        <a href = "{{ authrocket_url }}/profile"><button class = "btn btn-primary">
+            View AuthRocket Profile
+        </button></a>
     </p>
+    
+    <p>If you do not receive this email within a few minutes and have checked your spam/junk mail folders, please contact us at
+    <a href="mailto:microsetta@ucsd.edu">microsetta@ucsd.edu</a>.
     {% endif %}
 {% else %}
     You are not logged in. Please click to either: <br/>


### PR DESCRIPTION
- Updated wording for post-login creation
- Switched button out to view AuthRocket Profile (I can't think of any use cases for a refresh button, since users should ideally go to email -> find confirmation email -> click on confirmation -> be directed to a refreshed home page)